### PR TITLE
Add required settings

### DIFF
--- a/henson_sqs/__init__.py
+++ b/henson_sqs/__init__.py
@@ -127,6 +127,14 @@ class SQS(Extension):
         'SQS_WAIT_TIME': 20,
     }
 
+    REQUIRED_SETTINGS = (
+        'AWS_ACCESS_KEY',
+        'AWS_ACCESS_SECRET',
+        'AWS_REGION_NAME',
+        'SQS_INBOUND_QUEUE_URL',
+        'SQS_OUTBOUND_QUEUE_URL',
+    )
+
     @lazy
     def client(self):
         """Return the connection to SQS.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=[
         'boto3>=1.1.1',
-        'Henson>=0.2.0',
+        'Henson>=0.3.0',
         'lazy>=1.2',
     ],
     tests_require=[


### PR DESCRIPTION
As of Henson 0.3.0, extensions support the concept of required settings.
Henson-SQS has implicitly required settings. With this change, the SQS
instance will fail during init_app if the required settings are not
specified rather than failing due to KeyErrors or other internal issues
during message transport.
