### PR TITLE
Delete messages before yielding

### DIFF
--- a/henson_sqs/__init__.py
+++ b/henson_sqs/__init__.py
@@ -65,12 +65,12 @@ class Consumer:
             )
             for message in messages.get('Messages', []):
                 message['Body'] = json.loads(message['Body'])
-                yield message
                 if self.delete_messages_on_read:
                     self.client.delete_message(
                         QueueUrl=self.queue_url,
                         ReceiptHandle=message['ReceiptHandle'],
                     )
+                yield message
 
 
 class Producer:


### PR DESCRIPTION
When iterating over messages in the SQS queue, the messages must be
deleted by the caller reading them (otherwise, they become visible again
after the queue's visibility timeout). Currently, the message is yielded
prior to deletion. This is fine as long as the queue is continually
being populated and read from, but it may cause issues when there are no
messages entering the queue for a time period greater than the
visibility timeout (i.e. the "final" message in the queue will not be
deleted and will become visible for reading again, causing duplicate
processing). This change deletes the message before yielding, so
messages are always removed from the queue regardless of the existence
of other messages.

This is a bugfix change. It has the side effect of removing some
"built-in retry" functionality that exists based on the lack of message
deletion when exceptions are raised during the processing of messages.
Applications should not rely on this behavior and should instead use the
henson.contrib.retry.Retry plugin if developers wish to add this
functionality.
