### PR TITLE
Add a message_acknowledgement callback

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,9 @@ Release TBD
 
 - Update Henson-SQS to use asyncio coroutines for sending and receiving
   messages as required by Henson>=0.5.0 (*Backwards Incompatible*)
+- Register a message acknowledgement callback to delete the incoming message
+  from the queue after processing has finished
+- Remove the ``SQS_DELETE_MESSAGES_ON_READ`` setting
 
 
 Version 0.1.1


### PR DESCRIPTION
The newly added callback is automatically registered with the Henson
application when the consumer is initialized. The
`SQS_DELETE_MESSAGES_ON_READ` setting previously controlled whether or
not to delete messages immediately after reading them from the SQS
queue. It is unneeded now that deletes happen after processing has
completed (i.e. messages will not be deleted without being processed,
e.g. in the case of an application being terminated mid-message).
