### PR TITLE
Make message_acknowledgement method private

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,6 +4,18 @@ API
 
 Here's the public API for Henson-SQS.
 
+Consumer
+========
+
+.. autoclass:: henson_sqs.Consumer
+   :members:
+
+Producer
+========
+
+.. autoclass:: henson_sqs.Producer
+   :members:
+
 SQS
 ===
 

--- a/henson_sqs/__init__.py
+++ b/henson_sqs/__init__.py
@@ -39,10 +39,10 @@ class Consumer:
         """Initialize the consumer."""
         self.app = app
         self.client = client
-        self.app.message_acknowledgement(self.acknowledge_message)
+        self.app.message_acknowledgement(self._acknowledge_message)
 
     @asyncio.coroutine
-    def acknowledge_message(self, app, message):
+    def _acknowledge_message(self, app, message):
         """Delete a message from the SQS inbound queue.
 
         Args:


### PR DESCRIPTION
Rename `Consumer.acknowledge_message` to
`Consumer._acknowledge_message` and add `Consumer` and `Producer`
to API docs.
