### PR TITLE
Make AWS access credentials optional

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,6 +12,7 @@ Release TBD
 - Register a message acknowledgement callback to delete the incoming message
   from the queue after processing has finished
 - Remove the ``SQS_DELETE_MESSAGES_ON_READ`` setting
+- Make queue URL and AWS credentials settings optional
 
 
 Version 0.1.1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ Quickstart
     from henson import Application
     from henson_sqs import SQS
 
-    app = Henson(__name__)
+    app = Application(__name__)
     sqs = SQS(app)
 
     app.consumer = sqs.consumer()
@@ -30,33 +30,33 @@ Configuration
 The following settings are used by Henson-SQS:
 
 ===============================    ============================================
-``AWS_ACCESS_KEY``                 The access key used to connect to AWS
-                                   required
-``AWS_ACCESS_SECRET``              The access secret used to connect to AWS
-                                   required
-``AWS_REGION_NAME``                The AWS region to use
-                                   required
+``AWS_ACCESS_KEY``                 The access key used to connect to AWS.
+                                   default: ``None``
+``AWS_ACCESS_SECRET``              The access secret used to connect to AWS.
+                                   default: ``None``
+``AWS_REGION_NAME``                The AWS region to use.
+                                   default: ``None``
 ``SQS_INBOUND_QUEUE_URL``          The URL representing the SQS queue to be
-                                   used for inbound messages
+                                   used for inbound messages.
                                    required
 ``SQS_OUTBOUND_QUEUE_URL``         The URL representing the SQS queue to be
-                                   used for outbound messages
+                                   used for outbound messages.
                                    required
 ``SQS_ATTRIBUTE_NAMES``            A list of names of metadata attributes to be
-                                   fetched with inbound queue messages
+                                   fetched with inbound queue messages.
                                    default: ``['All']``
-``SQS_MESSAGE_ATTRIBUTE_NAMES``    A list of message attributes to be fetched
+``SQS_MESSAGE_ATTRIBUTE_NAMES``    A list of message attributes to be fetched.
                                    default: ``['All']``
-``SQS_MESSAGE_BATCH_SIZE``         Number of messages to be fetched with each
-                                   call to SQS
+``SQS_MESSAGE_BATCH_SIZE``         Number of messages to be fetched with each.
+                                   call to SQS.
                                    default: ``10``
 ``SQS_VISIBILITY_TIMEOUT``         How long (in seconds) a message should be
                                    hidden from subsequent retrievals before
-                                   becoming available for consumption again
+                                   becoming available for consumption again.
                                    default: ``60``
 ``SQS_WAIT_TIME``                  How long (in seconds) calls to
                                    ``receive_message`` should wait before
-                                   returning if no messages are in the queue
+                                   returning if no messages are in the queue.
                                    default: ``20``
 ===============================    ============================================
 

--- a/henson_sqs/__init__.py
+++ b/henson_sqs/__init__.py
@@ -150,13 +150,10 @@ class SQS(Extension):
         'SQS_OUTBOUND_QUEUE_URL': None,
         'SQS_VISIBILITY_TIMEOUT': 60,
         'SQS_WAIT_TIME': 20,
+        'AWS_ACCESS_KEY': None,
+        'AWS_ACCESS_SECRET': None,
+        'AWS_REGION_NAME': None,
     }
-
-    REQUIRED_SETTINGS = (
-        'AWS_ACCESS_KEY',
-        'AWS_ACCESS_SECRET',
-        'AWS_REGION_NAME',
-    )
 
     @lazy
     def client(self):


### PR DESCRIPTION
In some cases, AWS authentication is handled via other mechanisms (e.g.
environment variables or EC2 instance profiles). These settings should
not be required in order to support those use cases.
