### PR TITLE
Use Sphinx's builtin Napoleon extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,9 +34,9 @@ sys.path.insert(0, os.path.abspath('..'))
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
+    'sphinx.ext.napoleon',
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
-    'sphinxcontrib.napoleon',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,7 @@ deps =
     henson
     boto3
     lazy
-    sphinx
-    sphinxcontrib-napoleon
+    sphinx>=1.3
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     doc8 --allow-long-titles README.rst docs/ --ignore-path docs/_build/


### PR DESCRIPTION
Docstrings throughout Henson-SQS adhere to the Google Python Style
Guide.  The Napoleon extension is used to parse them. Rather than
installing it separately, it was graduated to a builtin extension in
Sphinx 1.3
