### PR TITLE
Update the Read the Docs domain

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -295,5 +295,5 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3.4', None),
-    'boto3': ('https://boto3.readthedocs.org/en/latest/', None),
+    'boto3': ('https://boto3.readthedocs.io/en/latest/', None),
 }


### PR DESCRIPTION
Read the Docs has switched from using readthedocs.org to readthedocs.io
for project documentation. It includes the added benefit of having
better HTTPS support.
