### PR TITLE
Add sphinx_rtd_theme dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     boto3
     lazy
     sphinx>=1.3
+    sphinx_rtd_theme
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     doc8 --allow-long-titles README.rst docs/ --ignore-path docs/_build/


### PR DESCRIPTION
`sphinx_rtd_theme` is no longer bundled with `sphinx`, so explicitly
require it.