### PR TITLE
Explicitly pass the loop to the internal message queue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Release TBD
   from the queue after processing has finished
 - Remove the ``SQS_DELETE_MESSAGES_ON_READ`` setting
 - Make queue URL and AWS credentials settings optional
+- Bugfix: postpone internal message queue creation until it's needed by the
+  `_consume` function
 
 
 Version 0.1.1

--- a/henson_sqs/__init__.py
+++ b/henson_sqs/__init__.py
@@ -54,8 +54,6 @@ class Consumer:
         self.app = app
         self.client = client
         self._consuming = False
-        self._message_queue = asyncio.Queue(
-            maxsize=self.app.settings['SQS_PREFETCH_LIMIT'])
         self.app.message_acknowledgement(self._acknowledge_message)
 
     @asyncio.coroutine
@@ -78,6 +76,10 @@ class Consumer:
         """Begin consuming from the SQS queue."""
         self._consuming = True
         loop = asyncio.get_event_loop()
+        self._message_queue = asyncio.Queue(
+            maxsize=self.app.settings['SQS_PREFETCH_LIMIT'],
+            loop=loop,
+        )
         loop.create_task(self._consume())
 
     @asyncio.coroutine


### PR DESCRIPTION
Currently, anything that calls `asyncio.set_event_loop` after a
Henson-SQS `Consumer` is created will not affect the consumer's internal
message queue. This causes the loop and the consume tasks to bind to
different loops and the application to fail. Passing the loop explicitly
addresses this issue.