### PR TITLE
Get Build Up To Date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: python
+
+matrix:
+  include:
+    - python: 3.4
+      env: TOX_ENV=py34
+    - python: 3.5
+      env: TOX_ENV=py35
+    - python: 3.6
+      env: TOX_ENV=py36
+    - python: 3.6
+      env: TOX_ENV=docs
+    - python: 3.6
+      env: TOX_ENV=pep8
+
+install: pip install tox
+script: tox -e $TOX_ENV
+
+# Control the branches that get built.
+branches:
+  only:
+    - master

--- a/henson_sqs/__init__.py
+++ b/henson_sqs/__init__.py
@@ -112,6 +112,7 @@ class Consumer:
 
         Returns:
             dict: A JSON-decoded message.
+
         """
         if not self._consuming:
             yield from self._begin_consuming()
@@ -194,6 +195,7 @@ class SQS(Extension):
 
         Returns:
             boto3.SQS.Client: A connection to the SQS service.
+
         """
         session = Session(
             aws_access_key_id=self.app.settings['AWS_ACCESS_KEY'],
@@ -207,6 +209,7 @@ class SQS(Extension):
 
         Returns:
             Consumer: The new consumer.
+
         """
         return Consumer(app=self.app, client=self.client)
 
@@ -215,5 +218,6 @@ class SQS(Extension):
 
         Returns:
             Producer: The new producer.
+
         """
         return Producer(app=self.app, client=self.client)

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Software Development :: Libraries :: Application Frameworks',
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = docs,pep8,py34
+envlist = docs,pep8,py34,py35,py36
 
 [testenv:docs]
-basepython = python3.4
+basepython = python3.6
 deps =
     doc8
     henson
@@ -15,7 +15,7 @@ commands =
     doc8 --allow-long-titles README.rst docs/ --ignore-path docs/_build/
 
 [testenv:pep8]
-basepython = python3.4
+basepython = python3.6
 deps =
     flake8-docstrings
     pep8-naming


### PR DESCRIPTION
Fixes the following PEP257 error:

- `D413 Missing blank line after last section`

Also, some miscellaneous work to get build up to date.