### PR TITLE
just a missing return......unretrieved-exception-bug

### DIFF
--- a/henson_sqs/__init__.py
+++ b/henson_sqs/__init__.py
@@ -80,7 +80,7 @@ class Consumer:
             maxsize=self.app.settings['SQS_PREFETCH_LIMIT'],
             loop=loop,
         )
-        loop.create_task(self._consume())
+        return loop.create_task(self._consume())
 
     @asyncio.coroutine
     def _consume(self):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=[
         'boto3>=1.1.1',
-        'Henson>=0.5.0',
+        'Henson>=1.2.0',
         'lazy>=1.2',
     ],
     tests_require=[


### PR DESCRIPTION
So. this is a crazy one and took a bit of digging to handle properly.

so the _begin_consuming function needs a return.

```
    def _begin_consuming(self):
        """Begin consuming from the SQS queue."""
        self._consuming = True
        loop = asyncio.get_event_loop()
        self._message_queue = asyncio.Queue(
            maxsize=self.app.settings['SQS_PREFETCH_LIMIT'],
            loop=loop,
        )
        return loop.create_task(self._consume())
```

The _consume() method is an infinite while loop that never exists normally. However, when an exception is triggered, the task completes
```
    @asyncio.coroutine
    def read(self):
        """Read a single message from the message queue.

        Returns:
            dict: A JSON-decoded message.

        """
        if not self._consuming:
            yield from self._begin_consuming()
        return (yield from self._message_queue.get())
```

Because of the  `yield from self._begin_consuming()`, and the fact there was no return in begin_consuming, the exception was not propagating to Henson. The future remains unconsumed without that return.

The fix is to add a return. Now, when Henson-SQS encounters an exception, it will propagate all the way up to Henson and the application should terminate. 
