### PR TITLE
revert return

### DIFF
--- a/henson_sqs/__init__.py
+++ b/henson_sqs/__init__.py
@@ -80,7 +80,7 @@ class Consumer:
             maxsize=self.app.settings['SQS_PREFETCH_LIMIT'],
             loop=loop,
         )
-        return loop.create_task(self._consume())
+        loop.create_task(self._consume())
 
     @asyncio.coroutine
     def _consume(self):


### PR DESCRIPTION
we need to revert this return. While the return allows exceptions to be bubbled up, there is an issue where Henson is not able to process messages. This original bug requires more investigation. For now, we need to revert so that relay can work.